### PR TITLE
Upgrade black that was not compatible with latest versions of Python 3.9

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
-black==19.10b0
+black==22.6.0
 mypy==0.790
 pylint==2.6.0
 pytest-cov==2.10.1


### PR DESCRIPTION
Error was : undefined symbol: _PyUnicode_DecodeUnicodeEscape
