### PR TITLE
Fix parsing of command line parameter overrides using whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [0.7.1] - 2022-09-28
+
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+- Incorrectly parsed command line parameter for overrides using whitespace (`--key value`)
+
+### Security
+
+
 ## [0.7.0] - 2022-08-26
 
 ### Added

--- a/fromconfig/cli/main.py
+++ b/fromconfig/cli/main.py
@@ -52,8 +52,8 @@ def parse_args():
 
     argv = sys.argv[1:]
     fire.Fire(_parse_args, argv)
-    num_args_used = len(_paths) + len(_overrides) + 1  # +1 for the fire separator
-    command = " ".join(argv[num_args_used:])
+    idx_of_fire_separator = len(argv) if "-" not in argv else argv.index("-")
+    command = " ".join(argv[idx_of_fire_separator + 1 :])
     return _paths, _overrides, command
 
 

--- a/fromconfig/version.py
+++ b/fromconfig/version.py
@@ -1,6 +1,6 @@
 # pylint: disable=all
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 __author__ = "Criteo"
 
 __major__ = __version__.split(".")[0]

--- a/tests/unit/cli/test_cli_main.py
+++ b/tests/unit/cli/test_cli_main.py
@@ -17,6 +17,16 @@ def capture(command):
 
 def test_cli_parse_args():
     """Test cli.parse_args."""
+    argv = ["fromconfig", "config.yaml", "params.yaml", "-", "model", "-", "train"]
+    with patch.object(sys, "argv", argv):
+        paths, overrides, command = parse_args()
+        expected_paths = ["config.yaml", "params.yaml"]
+        expected_overrides = {}
+        expected_command = "model - train"
+        assert paths == expected_paths
+        assert overrides == expected_overrides
+        assert command == expected_command
+
     argv = ["fromconfig", "config.yaml", "--output", "/tmp", "-", "run"]
     with patch.object(sys, "argv", argv):
         paths, overrides, command = parse_args()

--- a/tests/unit/cli/test_cli_main.py
+++ b/tests/unit/cli/test_cli_main.py
@@ -1,15 +1,41 @@
 """Tests for cli.main."""
 
 import fromconfig
+from fromconfig.cli.main import parse_args
+import sys
+from unittest.mock import patch
 
 import subprocess
 
 
 def capture(command):
-    """Utility to execute and capture the result of a commmand."""
+    """Utility to execute and capture the result of a command."""
     proc = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     out, err = proc.communicate()
     return out, err, proc.returncode
+
+
+def test_cli_parse_args():
+    """Test cli.parse_args."""
+    argv = ["fromconfig", "config.yaml", "--output", "/tmp", "-", "run"]
+    with patch.object(sys, "argv", argv):
+        paths, overrides, command = parse_args()
+        expected_paths = ["config.yaml"]
+        expected_overrides = {"output": "/tmp"}
+        expected_command = "run"
+        assert paths == expected_paths
+        assert overrides == expected_overrides
+        assert command == expected_command
+
+    argv = ["fromconfig", "config.yaml", "--output=/tmp", "-", "run"]
+    with patch.object(sys, "argv", argv):
+        paths, overrides, command = parse_args()
+        expected_paths = ["config.yaml"]
+        expected_overrides = {"output": "/tmp"}
+        expected_command = "run"
+        assert paths == expected_paths
+        assert overrides == expected_overrides
+        assert command == expected_command
 
 
 def test_cli_main_nothing():


### PR DESCRIPTION
Close #37 