### PR TITLE
Fix bug while parsing dummy mappings (i.e. dict) introduced with lazy args

### DIFF
--- a/fromconfig/parser/evaluate.py
+++ b/fromconfig/parser/evaluate.py
@@ -181,8 +181,13 @@ class EvaluateParser(base.Parser):
                 if evaluate == EvaluateMode.PARTIAL:
 
                     def is_lazy(arg):
-                        # Argument will be parsed before the function itself and hence lazy arguments would have been wrapped into a _LazyArg
-                        return bool(is_mapping(arg) and arg[Keys.ATTR.value] == to_import_string(_LazyArg))
+                        # Argument will be parsed before the function itself and hence lazy arguments would have been
+                        # wrapped into a _LazyArg
+                        return bool(
+                            is_mapping(arg)
+                            and Keys.ATTR.value in arg
+                            and arg[Keys.ATTR.value] == to_import_string(_LazyArg)
+                        )
 
                     lazy_args_mask = [is_lazy(arg) for arg in args]
                     lazy_kwargs_map = {key: is_lazy(value) for key, value in kwargs.items()}

--- a/tests/unit/parser/test_parser_evaluate.py
+++ b/tests/unit/parser/test_parser_evaluate.py
@@ -10,9 +10,15 @@ import fromconfig
     "config, expected",
     [
         pytest.param(None, None, id="none"),
+        pytest.param({"a": 1, "b": 2}, {"a": 1, "b": 2}, id="dummy_mapping"),
         pytest.param({"_attr_": "str", "_eval_": "import"}, str, id="import"),
         pytest.param({"_attr_": "str", "_args_": ["hello"], "_eval_": "call"}, "hello", id="call"),
         pytest.param({"_attr_": "str", "_args_": ["hello"], "_eval_": "partial"}, lambda: "hello", id="partial"),
+        pytest.param(
+            {"_attr_": "str", "_args_": [{"hello": "world"}], "_eval_": "partial"},
+            lambda: "{'hello': 'world'}",
+            id="partial_with_dummy_mapping",
+        ),
     ],
 )
 def test_parser_evaluate(config, expected):


### PR DESCRIPTION
The test with id partial_with_dummy_mapping was failing before this fix